### PR TITLE
Adding swephgoMutex

### DIFF
--- a/swephgo.go
+++ b/swephgo.go
@@ -24,7 +24,10 @@ import "C"
 import (
 	"runtime"
 	"unsafe"
+	"sync"
 )
+
+var swephgoMutex sync.Mutex
 
 // HeliacalUt function as declared in src/swephexp.h:681
 func HeliacalUt(tjdstartUt float64, geopos []float64, datm []float64, dobs []float64, objectName []byte, typeEvent int, iflag int, dret []float64, serr []byte) int32 {
@@ -37,6 +40,8 @@ func HeliacalUt(tjdstartUt float64, geopos []float64, datm []float64, dobs []flo
 	ciflag, ciflagAllocMap := (C.int32)(iflag), cgoAllocsUnknown
 	cdret, cdretAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&dret)))
 	cserr, cserrAllocMap := copyPCharBytes((*sliceHeader)(unsafe.Pointer(&serr)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_heliacal_ut(ctjdstartUt, cgeopos, cdatm, cdobs, cobjectName, ctypeEvent, ciflag, cdret, cserr)
 	runtime.KeepAlive(cserrAllocMap)
 	runtime.KeepAlive(cdretAllocMap)
@@ -62,6 +67,8 @@ func HeliacalPhenoUt(tjdUt float64, geopos []float64, datm []float64, dobs []flo
 	chelflag, chelflagAllocMap := (C.int32)(helflag), cgoAllocsUnknown
 	cdarr, cdarrAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&darr)))
 	cserr, cserrAllocMap := copyPCharBytes((*sliceHeader)(unsafe.Pointer(&serr)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_heliacal_pheno_ut(ctjdUt, cgeopos, cdatm, cdobs, cobjectName, ctypeEvent, chelflag, cdarr, cserr)
 	runtime.KeepAlive(cserrAllocMap)
 	runtime.KeepAlive(cdarrAllocMap)
@@ -86,6 +93,8 @@ func VisLimitMag(tjdut float64, geopos []float64, datm []float64, dobs []float64
 	chelflag, chelflagAllocMap := (C.int32)(helflag), cgoAllocsUnknown
 	cdret, cdretAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&dret)))
 	cserr, cserrAllocMap := copyPCharBytes((*sliceHeader)(unsafe.Pointer(&serr)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_vis_limit_mag(ctjdut, cgeopos, cdatm, cdobs, cobjectName, chelflag, cdret, cserr)
 	runtime.KeepAlive(cserrAllocMap)
 	runtime.KeepAlive(cdretAllocMap)
@@ -113,6 +122,8 @@ func HeliacalAngle(tjdut float64, dgeo []float64, datm []float64, dobs []float64
 	caltMoon, caltMoonAllocMap := (C.double)(altMoon), cgoAllocsUnknown
 	cdret, cdretAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&dret)))
 	cserr, cserrAllocMap := copyPCharBytes((*sliceHeader)(unsafe.Pointer(&serr)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_heliacal_angle(ctjdut, cdgeo, cdatm, cdobs, chelflag, cmag, caziObj, caziSun, caziMoon, caltMoon, cdret, cserr)
 	runtime.KeepAlive(cserrAllocMap)
 	runtime.KeepAlive(cdretAllocMap)
@@ -145,6 +156,8 @@ func TopoArcusVisionis(tjdut float64, dgeo []float64, datm []float64, dobs []flo
 	caltMoon, caltMoonAllocMap := (C.double)(altMoon), cgoAllocsUnknown
 	cdret, cdretAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&dret)))
 	cserr, cserrAllocMap := copyPCharBytes((*sliceHeader)(unsafe.Pointer(&serr)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_topo_arcus_visionis(ctjdut, cdgeo, cdatm, cdobs, chelflag, cmag, caziObj, caltObj, caziSun, caziMoon, caltMoon, cdret, cserr)
 	runtime.KeepAlive(cserrAllocMap)
 	runtime.KeepAlive(cdretAllocMap)
@@ -167,6 +180,8 @@ func TopoArcusVisionis(tjdut float64, dgeo []float64, datm []float64, dobs []flo
 func SetAstroModels(samod []byte, iflag int32) {
 	csamod, csamodAllocMap := copyPCharBytes((*sliceHeader)(unsafe.Pointer(&samod)))
 	ciflag, ciflagAllocMap := (C.int32)(iflag), cgoAllocsUnknown
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	C.swe_set_astro_models(csamod, ciflag)
 	runtime.KeepAlive(ciflagAllocMap)
 	runtime.KeepAlive(csamodAllocMap)
@@ -177,6 +192,8 @@ func GetAstroModels(samod []byte, sdet []byte, iflag int32) {
 	csamod, csamodAllocMap := copyPCharBytes((*sliceHeader)(unsafe.Pointer(&samod)))
 	csdet, csdetAllocMap := copyPCharBytes((*sliceHeader)(unsafe.Pointer(&sdet)))
 	ciflag, ciflagAllocMap := (C.int32)(iflag), cgoAllocsUnknown
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	C.swe_get_astro_models(csamod, csdet, ciflag)
 	runtime.KeepAlive(ciflagAllocMap)
 	runtime.KeepAlive(csdetAllocMap)
@@ -186,6 +203,8 @@ func GetAstroModels(samod []byte, sdet []byte, iflag int32) {
 // Version function as declared in src/swephexp.h:698
 func Version(arg0 []byte) *byte {
 	carg0, carg0AllocMap := copyPCharBytes((*sliceHeader)(unsafe.Pointer(&arg0)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_version(carg0)
 	runtime.KeepAlive(carg0AllocMap)
 	__v := *(**byte)(unsafe.Pointer(&__ret))
@@ -195,6 +214,8 @@ func Version(arg0 []byte) *byte {
 // GetLibraryPath function as declared in src/swephexp.h:699
 func GetLibraryPath(arg0 []byte) *byte {
 	carg0, carg0AllocMap := copyPCharBytes((*sliceHeader)(unsafe.Pointer(&arg0)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_get_library_path(carg0)
 	runtime.KeepAlive(carg0AllocMap)
 	__v := *(**byte)(unsafe.Pointer(&__ret))
@@ -208,6 +229,8 @@ func Calc(tjd float64, ipl int, iflag int, xx []float64, serr []byte) int32 {
 	ciflag, ciflagAllocMap := (C.int32)(iflag), cgoAllocsUnknown
 	cxx, cxxAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&xx)))
 	cserr, cserrAllocMap := copyPCharBytes((*sliceHeader)(unsafe.Pointer(&serr)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_calc(ctjd, cipl, ciflag, cxx, cserr)
 	runtime.KeepAlive(cserrAllocMap)
 	runtime.KeepAlive(cxxAllocMap)
@@ -225,6 +248,8 @@ func CalcUt(tjdUt float64, ipl int, iflag int, xx []float64, serr []byte) int32 
 	ciflag, ciflagAllocMap := (C.int32)(iflag), cgoAllocsUnknown
 	cxx, cxxAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&xx)))
 	cserr, cserrAllocMap := copyPCharBytes((*sliceHeader)(unsafe.Pointer(&serr)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_calc_ut(ctjdUt, cipl, ciflag, cxx, cserr)
 	runtime.KeepAlive(cserrAllocMap)
 	runtime.KeepAlive(cxxAllocMap)
@@ -243,6 +268,8 @@ func CalcPctr(tjd float64, ipl int, iplctr int, iflag int, xxret []float64, serr
 	ciflag, ciflagAllocMap := (C.int32)(iflag), cgoAllocsUnknown
 	cxxret, cxxretAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&xxret)))
 	cserr, cserrAllocMap := copyPCharBytes((*sliceHeader)(unsafe.Pointer(&serr)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_calc_pctr(ctjd, cipl, ciplctr, ciflag, cxxret, cserr)
 	runtime.KeepAlive(cserrAllocMap)
 	runtime.KeepAlive(cxxretAllocMap)
@@ -261,6 +288,8 @@ func Fixstar(star []byte, tjd float64, iflag int, xx []float64, serr []byte) int
 	ciflag, ciflagAllocMap := (C.int32)(iflag), cgoAllocsUnknown
 	cxx, cxxAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&xx)))
 	cserr, cserrAllocMap := copyPCharBytes((*sliceHeader)(unsafe.Pointer(&serr)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_fixstar(cstar, ctjd, ciflag, cxx, cserr)
 	runtime.KeepAlive(cserrAllocMap)
 	runtime.KeepAlive(cxxAllocMap)
@@ -278,6 +307,8 @@ func FixstarUt(star []byte, tjdUt float64, iflag int, xx []float64, serr []byte)
 	ciflag, ciflagAllocMap := (C.int32)(iflag), cgoAllocsUnknown
 	cxx, cxxAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&xx)))
 	cserr, cserrAllocMap := copyPCharBytes((*sliceHeader)(unsafe.Pointer(&serr)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_fixstar_ut(cstar, ctjdUt, ciflag, cxx, cserr)
 	runtime.KeepAlive(cserrAllocMap)
 	runtime.KeepAlive(cxxAllocMap)
@@ -293,6 +324,8 @@ func FixstarMag(star []byte, mag []float64, serr []byte) int32 {
 	cstar, cstarAllocMap := copyPCharBytes((*sliceHeader)(unsafe.Pointer(&star)))
 	cmag, cmagAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&mag)))
 	cserr, cserrAllocMap := copyPCharBytes((*sliceHeader)(unsafe.Pointer(&serr)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_fixstar_mag(cstar, cmag, cserr)
 	runtime.KeepAlive(cserrAllocMap)
 	runtime.KeepAlive(cmagAllocMap)
@@ -308,6 +341,8 @@ func Fixstar2(star []byte, tjd float64, iflag int, xx []float64, serr []byte) in
 	ciflag, ciflagAllocMap := (C.int32)(iflag), cgoAllocsUnknown
 	cxx, cxxAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&xx)))
 	cserr, cserrAllocMap := copyPCharBytes((*sliceHeader)(unsafe.Pointer(&serr)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_fixstar2(cstar, ctjd, ciflag, cxx, cserr)
 	runtime.KeepAlive(cserrAllocMap)
 	runtime.KeepAlive(cxxAllocMap)
@@ -325,6 +360,8 @@ func Fixstar2Ut(star []byte, tjdUt float64, iflag int, xx []float64, serr []byte
 	ciflag, ciflagAllocMap := (C.int32)(iflag), cgoAllocsUnknown
 	cxx, cxxAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&xx)))
 	cserr, cserrAllocMap := copyPCharBytes((*sliceHeader)(unsafe.Pointer(&serr)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_fixstar2_ut(cstar, ctjdUt, ciflag, cxx, cserr)
 	runtime.KeepAlive(cserrAllocMap)
 	runtime.KeepAlive(cxxAllocMap)
@@ -340,6 +377,8 @@ func Fixstar2Mag(star []byte, mag []float64, serr []byte) int32 {
 	cstar, cstarAllocMap := copyPCharBytes((*sliceHeader)(unsafe.Pointer(&star)))
 	cmag, cmagAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&mag)))
 	cserr, cserrAllocMap := copyPCharBytes((*sliceHeader)(unsafe.Pointer(&serr)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_fixstar2_mag(cstar, cmag, cserr)
 	runtime.KeepAlive(cserrAllocMap)
 	runtime.KeepAlive(cmagAllocMap)
@@ -350,12 +389,16 @@ func Fixstar2Mag(star []byte, mag []float64, serr []byte) int32 {
 
 // Close function as declared in src/swephexp.h:734
 func Close() {
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	C.swe_close()
 }
 
 // SetEphePath function as declared in src/swephexp.h:737
 func SetEphePath(path []byte) {
 	cpath, cpathAllocMap := copyPCharBytes((*sliceHeader)(unsafe.Pointer(&path)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	C.swe_set_ephe_path(cpath)
 	runtime.KeepAlive(cpathAllocMap)
 }
@@ -363,6 +406,8 @@ func SetEphePath(path []byte) {
 // SetJplFile function as declared in src/swephexp.h:740
 func SetJplFile(fname []byte) {
 	cfname, cfnameAllocMap := copyPCharBytes((*sliceHeader)(unsafe.Pointer(&fname)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	C.swe_set_jpl_file(cfname)
 	runtime.KeepAlive(cfnameAllocMap)
 }
@@ -371,6 +416,8 @@ func SetJplFile(fname []byte) {
 func GetPlanetName(ipl int, spname []byte) *byte {
 	cipl, ciplAllocMap := (C.int)(ipl), cgoAllocsUnknown
 	cspname, cspnameAllocMap := copyPCharBytes((*sliceHeader)(unsafe.Pointer(&spname)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_get_planet_name(cipl, cspname)
 	runtime.KeepAlive(cspnameAllocMap)
 	runtime.KeepAlive(ciplAllocMap)
@@ -383,6 +430,8 @@ func SetTopo(geolon float64, geolat float64, geoalt float64) {
 	cgeolon, cgeolonAllocMap := (C.double)(geolon), cgoAllocsUnknown
 	cgeolat, cgeolatAllocMap := (C.double)(geolat), cgoAllocsUnknown
 	cgeoalt, cgeoaltAllocMap := (C.double)(geoalt), cgoAllocsUnknown
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	C.swe_set_topo(cgeolon, cgeolat, cgeoalt)
 	runtime.KeepAlive(cgeoaltAllocMap)
 	runtime.KeepAlive(cgeolatAllocMap)
@@ -394,6 +443,8 @@ func SetSidMode(sidMode int, t0 float64, ayanT0 float64) {
 	csidMode, csidModeAllocMap := (C.int32)(sidMode), cgoAllocsUnknown
 	ct0, ct0AllocMap := (C.double)(t0), cgoAllocsUnknown
 	cayanT0, cayanT0AllocMap := (C.double)(ayanT0), cgoAllocsUnknown
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	C.swe_set_sid_mode(csidMode, ct0, cayanT0)
 	runtime.KeepAlive(cayanT0AllocMap)
 	runtime.KeepAlive(ct0AllocMap)
@@ -406,6 +457,8 @@ func GetAyanamsaEx(tjdEt float64, iflag int, daya []float64, serr []byte) int32 
 	ciflag, ciflagAllocMap := (C.int32)(iflag), cgoAllocsUnknown
 	cdaya, cdayaAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&daya)))
 	cserr, cserrAllocMap := copyPCharBytes((*sliceHeader)(unsafe.Pointer(&serr)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_get_ayanamsa_ex(ctjdEt, ciflag, cdaya, cserr)
 	runtime.KeepAlive(cserrAllocMap)
 	runtime.KeepAlive(cdayaAllocMap)
@@ -421,6 +474,8 @@ func GetAyanamsaExUt(tjdUt float64, iflag int, daya []float64, serr []byte) int3
 	ciflag, ciflagAllocMap := (C.int32)(iflag), cgoAllocsUnknown
 	cdaya, cdayaAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&daya)))
 	cserr, cserrAllocMap := copyPCharBytes((*sliceHeader)(unsafe.Pointer(&serr)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_get_ayanamsa_ex_ut(ctjdUt, ciflag, cdaya, cserr)
 	runtime.KeepAlive(cserrAllocMap)
 	runtime.KeepAlive(cdayaAllocMap)
@@ -433,6 +488,8 @@ func GetAyanamsaExUt(tjdUt float64, iflag int, daya []float64, serr []byte) int3
 // GetAyanamsa function as declared in src/swephexp.h:754
 func GetAyanamsa(tjdEt float64) float64 {
 	ctjdEt, ctjdEtAllocMap := (C.double)(tjdEt), cgoAllocsUnknown
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_get_ayanamsa(ctjdEt)
 	runtime.KeepAlive(ctjdEtAllocMap)
 	__v := (float64)(__ret)
@@ -442,6 +499,8 @@ func GetAyanamsa(tjdEt float64) float64 {
 // GetAyanamsaUt function as declared in src/swephexp.h:755
 func GetAyanamsaUt(tjdUt float64) float64 {
 	ctjdUt, ctjdUtAllocMap := (C.double)(tjdUt), cgoAllocsUnknown
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_get_ayanamsa_ut(ctjdUt)
 	runtime.KeepAlive(ctjdUtAllocMap)
 	__v := (float64)(__ret)
@@ -451,6 +510,8 @@ func GetAyanamsaUt(tjdUt float64) float64 {
 // GetAyanamsaName function as declared in src/swephexp.h:758
 func GetAyanamsaName(isidmode int32) string {
 	cisidmode, cisidmodeAllocMap := (C.int32)(isidmode), cgoAllocsUnknown
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_get_ayanamsa_name(cisidmode)
 	runtime.KeepAlive(cisidmodeAllocMap)
 	__v := packPCharString(__ret)
@@ -463,6 +524,8 @@ func GetCurrentFileData(ifno int, tfstart []float64, tfend []float64, denum []in
 	ctfstart, ctfstartAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&tfstart)))
 	ctfend, ctfendAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&tfend)))
 	cdenum, cdenumAllocMap := copyPIntBytes((*sliceHeader)(unsafe.Pointer(&denum)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_get_current_file_data(cifno, ctfstart, ctfend, cdenum)
 	runtime.KeepAlive(cdenumAllocMap)
 	runtime.KeepAlive(ctfendAllocMap)
@@ -480,6 +543,8 @@ func DateConversion(y int, m int, d int, utime float64, c byte, tjd []float64) i
 	cutime, cutimeAllocMap := (C.double)(utime), cgoAllocsUnknown
 	cc, ccAllocMap := (C.char)(c), cgoAllocsUnknown
 	ctjd, ctjdAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&tjd)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_date_conversion(cy, cm, cd, cutime, cc, ctjd)
 	runtime.KeepAlive(ctjdAllocMap)
 	runtime.KeepAlive(ccAllocMap)
@@ -498,6 +563,8 @@ func Julday(year int, month int, day int, hour float64, gregflag int32) float64 
 	cday, cdayAllocMap := (C.int)(day), cgoAllocsUnknown
 	chour, chourAllocMap := (C.double)(hour), cgoAllocsUnknown
 	cgregflag, cgregflagAllocMap := (C.int)(gregflag), cgoAllocsUnknown
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_julday(cyear, cmonth, cday, chour, cgregflag)
 	runtime.KeepAlive(cgregflagAllocMap)
 	runtime.KeepAlive(chourAllocMap)
@@ -516,6 +583,8 @@ func Revjul(jd float64, gregflag int, jyear []int, jmon []int, jday []int, jut [
 	cjmon, cjmonAllocMap := copyPIntBytes((*sliceHeader)(unsafe.Pointer(&jmon)))
 	cjday, cjdayAllocMap := copyPIntBytes((*sliceHeader)(unsafe.Pointer(&jday)))
 	cjut, cjutAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&jut)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	C.swe_revjul(cjd, cgregflag, cjyear, cjmon, cjday, cjut)
 	runtime.KeepAlive(cjutAllocMap)
 	runtime.KeepAlive(cjdayAllocMap)
@@ -536,6 +605,8 @@ func UtcToJd(iyear int, imonth int, iday int, ihour int, imin int, dsec float64,
 	cgregflag, cgregflagAllocMap := (C.int32)(gregflag), cgoAllocsUnknown
 	cdret, cdretAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&dret)))
 	cserr, cserrAllocMap := copyPCharBytes((*sliceHeader)(unsafe.Pointer(&serr)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_utc_to_jd(ciyear, cimonth, ciday, cihour, cimin, cdsec, cgregflag, cdret, cserr)
 	runtime.KeepAlive(cserrAllocMap)
 	runtime.KeepAlive(cdretAllocMap)
@@ -560,6 +631,8 @@ func JdetToUtc(tjdEt float64, gregflag int, iyear []int, imonth []int, iday []in
 	cihour, cihourAllocMap := copyPInt32Bytes((*sliceHeader)(unsafe.Pointer(&ihour)))
 	cimin, ciminAllocMap := copyPInt32Bytes((*sliceHeader)(unsafe.Pointer(&imin)))
 	cdsec, cdsecAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&dsec)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	C.swe_jdet_to_utc(ctjdEt, cgregflag, ciyear, cimonth, ciday, cihour, cimin, cdsec)
 	runtime.KeepAlive(cdsecAllocMap)
 	runtime.KeepAlive(ciminAllocMap)
@@ -581,6 +654,8 @@ func Jdut1ToUtc(tjdUt float64, gregflag int, iyear []int, imonth []int, iday []i
 	cihour, cihourAllocMap := copyPInt32Bytes((*sliceHeader)(unsafe.Pointer(&ihour)))
 	cimin, ciminAllocMap := copyPInt32Bytes((*sliceHeader)(unsafe.Pointer(&imin)))
 	cdsec, cdsecAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&dsec)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	C.swe_jdut1_to_utc(ctjdUt, cgregflag, ciyear, cimonth, ciday, cihour, cimin, cdsec)
 	runtime.KeepAlive(cdsecAllocMap)
 	runtime.KeepAlive(ciminAllocMap)
@@ -607,6 +682,8 @@ func UtcTimeZone(iyear int, imonth int, iday int, ihour int, imin int, dsec floa
 	cihourOut, cihourOutAllocMap := copyPInt32Bytes((*sliceHeader)(unsafe.Pointer(&ihourOut)))
 	ciminOut, ciminOutAllocMap := copyPInt32Bytes((*sliceHeader)(unsafe.Pointer(&iminOut)))
 	cdsecOut, cdsecOutAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&dsecOut)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	C.swe_utc_time_zone(ciyear, cimonth, ciday, cihour, cimin, cdsec, cdTimezone, ciyearOut, cimonthOut, cidayOut, cihourOut, ciminOut, cdsecOut)
 	runtime.KeepAlive(cdsecOutAllocMap)
 	runtime.KeepAlive(ciminOutAllocMap)
@@ -631,6 +708,8 @@ func Houses(tjdUt float64, geolat float64, geolon float64, hsys int, cusps []flo
 	chsys, chsysAllocMap := (C.int)(hsys), cgoAllocsUnknown
 	ccusps, ccuspsAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&cusps)))
 	cascmc, cascmcAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&ascmc)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_houses(ctjdUt, cgeolat, cgeolon, chsys, ccusps, cascmc)
 	runtime.KeepAlive(cascmcAllocMap)
 	runtime.KeepAlive(ccuspsAllocMap)
@@ -651,6 +730,8 @@ func HousesEx(tjdUt float64, iflag int, geolat float64, geolon float64, hsys int
 	chsys, chsysAllocMap := (C.int)(hsys), cgoAllocsUnknown
 	ccusps, ccuspsAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&cusps)))
 	cascmc, cascmcAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&ascmc)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_houses_ex(ctjdUt, ciflag, cgeolat, cgeolon, chsys, ccusps, cascmc)
 	runtime.KeepAlive(cascmcAllocMap)
 	runtime.KeepAlive(ccuspsAllocMap)
@@ -675,6 +756,8 @@ func HousesEx2(tjdUt float64, iflag int, geolat float64, geolon float64, hsys in
 	ccuspSpeed, ccuspSpeedAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&cuspSpeed)))
 	cascmcSpeed, cascmcSpeedAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&ascmcSpeed)))
 	cserr, cserrAllocMap := copyPCharBytes((*sliceHeader)(unsafe.Pointer(&serr)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_houses_ex2(ctjdUt, ciflag, cgeolat, cgeolon, chsys, ccusps, cascmc, ccuspSpeed, cascmcSpeed, cserr)
 	runtime.KeepAlive(cserrAllocMap)
 	runtime.KeepAlive(cascmcSpeedAllocMap)
@@ -698,6 +781,8 @@ func HousesArmc(armc float64, geolat float64, eps float64, hsys int, cusps []flo
 	chsys, chsysAllocMap := (C.int)(hsys), cgoAllocsUnknown
 	ccusps, ccuspsAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&cusps)))
 	cascmc, cascmcAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&ascmc)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_houses_armc(carmc, cgeolat, ceps, chsys, ccusps, cascmc)
 	runtime.KeepAlive(cascmcAllocMap)
 	runtime.KeepAlive(ccuspsAllocMap)
@@ -720,6 +805,8 @@ func HousesArmcEx2(armc float64, geolat float64, eps float64, hsys int, cusps []
 	ccuspSpeed, ccuspSpeedAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&cuspSpeed)))
 	cascmcSpeed, cascmcSpeedAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&ascmcSpeed)))
 	cserr, cserrAllocMap := copyPCharBytes((*sliceHeader)(unsafe.Pointer(&serr)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_houses_armc_ex2(carmc, cgeolat, ceps, chsys, ccusps, cascmc, ccuspSpeed, cascmcSpeed, cserr)
 	runtime.KeepAlive(cserrAllocMap)
 	runtime.KeepAlive(cascmcSpeedAllocMap)
@@ -742,6 +829,8 @@ func HousePos(armc float64, geolat float64, eps float64, hsys int, xpin []float6
 	chsys, chsysAllocMap := (C.int)(hsys), cgoAllocsUnknown
 	cxpin, cxpinAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&xpin)))
 	cserr, cserrAllocMap := copyPCharBytes((*sliceHeader)(unsafe.Pointer(&serr)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_house_pos(carmc, cgeolat, ceps, chsys, cxpin, cserr)
 	runtime.KeepAlive(cserrAllocMap)
 	runtime.KeepAlive(cxpinAllocMap)
@@ -756,6 +845,8 @@ func HousePos(armc float64, geolat float64, eps float64, hsys int, xpin []float6
 // HouseName function as declared in src/swephexp.h:831
 func HouseName(hsys int32) *byte {
 	chsys, chsysAllocMap := (C.int)(hsys), cgoAllocsUnknown
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_house_name(chsys)
 	runtime.KeepAlive(chsysAllocMap)
 	__v := *(**byte)(unsafe.Pointer(&__ret))
@@ -774,6 +865,8 @@ func GauquelinSector(tUt float64, ipl int, starname []byte, iflag int, imeth int
 	cattemp, cattempAllocMap := (C.double)(attemp), cgoAllocsUnknown
 	cdgsect, cdgsectAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&dgsect)))
 	cserr, cserrAllocMap := copyPCharBytes((*sliceHeader)(unsafe.Pointer(&serr)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_gauquelin_sector(ctUt, cipl, cstarname, ciflag, cimeth, cgeopos, catpress, cattemp, cdgsect, cserr)
 	runtime.KeepAlive(cserrAllocMap)
 	runtime.KeepAlive(cdgsectAllocMap)
@@ -796,6 +889,8 @@ func SolEclipseWhere(tjd float64, ifl int, geopos []float64, attr []float64, ser
 	cgeopos, cgeoposAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&geopos)))
 	cattr, cattrAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&attr)))
 	cserr, cserrAllocMap := copyPCharBytes((*sliceHeader)(unsafe.Pointer(&serr)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_sol_eclipse_where(ctjd, cifl, cgeopos, cattr, cserr)
 	runtime.KeepAlive(cserrAllocMap)
 	runtime.KeepAlive(cattrAllocMap)
@@ -815,6 +910,8 @@ func LunOccultWhere(tjd float64, ipl int, starname []byte, ifl int, geopos []flo
 	cgeopos, cgeoposAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&geopos)))
 	cattr, cattrAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&attr)))
 	cserr, cserrAllocMap := copyPCharBytes((*sliceHeader)(unsafe.Pointer(&serr)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_lun_occult_where(ctjd, cipl, cstarname, cifl, cgeopos, cattr, cserr)
 	runtime.KeepAlive(cserrAllocMap)
 	runtime.KeepAlive(cattrAllocMap)
@@ -834,6 +931,8 @@ func SolEclipseHow(tjd float64, ifl int, geopos []float64, attr []float64, serr 
 	cgeopos, cgeoposAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&geopos)))
 	cattr, cattrAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&attr)))
 	cserr, cserrAllocMap := copyPCharBytes((*sliceHeader)(unsafe.Pointer(&serr)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_sol_eclipse_how(ctjd, cifl, cgeopos, cattr, cserr)
 	runtime.KeepAlive(cserrAllocMap)
 	runtime.KeepAlive(cattrAllocMap)
@@ -853,6 +952,8 @@ func SolEclipseWhenLoc(tjdStart float64, ifl int, geopos []float64, tret []float
 	cattr, cattrAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&attr)))
 	cbackward, cbackwardAllocMap := (C.int32)(backward), cgoAllocsUnknown
 	cserr, cserrAllocMap := copyPCharBytes((*sliceHeader)(unsafe.Pointer(&serr)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_sol_eclipse_when_loc(ctjdStart, cifl, cgeopos, ctret, cattr, cbackward, cserr)
 	runtime.KeepAlive(cserrAllocMap)
 	runtime.KeepAlive(cbackwardAllocMap)
@@ -876,6 +977,8 @@ func LunOccultWhenLoc(tjdStart float64, ipl int, starname []byte, ifl int, geopo
 	cattr, cattrAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&attr)))
 	cbackward, cbackwardAllocMap := (C.int32)(backward), cgoAllocsUnknown
 	cserr, cserrAllocMap := copyPCharBytes((*sliceHeader)(unsafe.Pointer(&serr)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_lun_occult_when_loc(ctjdStart, cipl, cstarname, cifl, cgeopos, ctret, cattr, cbackward, cserr)
 	runtime.KeepAlive(cserrAllocMap)
 	runtime.KeepAlive(cbackwardAllocMap)
@@ -898,6 +1001,8 @@ func SolEclipseWhenGlob(tjdStart float64, ifl int, ifltype int, tret []float64, 
 	ctret, ctretAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&tret)))
 	cbackward, cbackwardAllocMap := (C.int32)(backward), cgoAllocsUnknown
 	cserr, cserrAllocMap := copyPCharBytes((*sliceHeader)(unsafe.Pointer(&serr)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_sol_eclipse_when_glob(ctjdStart, cifl, cifltype, ctret, cbackward, cserr)
 	runtime.KeepAlive(cserrAllocMap)
 	runtime.KeepAlive(cbackwardAllocMap)
@@ -919,6 +1024,8 @@ func LunOccultWhenGlob(tjdStart float64, ipl int, starname []byte, ifl int, iflt
 	ctret, ctretAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&tret)))
 	cbackward, cbackwardAllocMap := (C.int32)(backward), cgoAllocsUnknown
 	cserr, cserrAllocMap := copyPCharBytes((*sliceHeader)(unsafe.Pointer(&serr)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_lun_occult_when_glob(ctjdStart, cipl, cstarname, cifl, cifltype, ctret, cbackward, cserr)
 	runtime.KeepAlive(cserrAllocMap)
 	runtime.KeepAlive(cbackwardAllocMap)
@@ -939,6 +1046,8 @@ func LunEclipseHow(tjdUt float64, ifl int, geopos []float64, attr []float64, ser
 	cgeopos, cgeoposAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&geopos)))
 	cattr, cattrAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&attr)))
 	cserr, cserrAllocMap := copyPCharBytes((*sliceHeader)(unsafe.Pointer(&serr)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_lun_eclipse_how(ctjdUt, cifl, cgeopos, cattr, cserr)
 	runtime.KeepAlive(cserrAllocMap)
 	runtime.KeepAlive(cattrAllocMap)
@@ -957,6 +1066,8 @@ func LunEclipseWhen(tjdStart float64, ifl int, ifltype int, tret []float64, back
 	ctret, ctretAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&tret)))
 	cbackward, cbackwardAllocMap := (C.int32)(backward), cgoAllocsUnknown
 	cserr, cserrAllocMap := copyPCharBytes((*sliceHeader)(unsafe.Pointer(&serr)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_lun_eclipse_when(ctjdStart, cifl, cifltype, ctret, cbackward, cserr)
 	runtime.KeepAlive(cserrAllocMap)
 	runtime.KeepAlive(cbackwardAllocMap)
@@ -977,6 +1088,8 @@ func LunEclipseWhenLoc(tjdStart float64, ifl int, geopos []float64, tret []float
 	cattr, cattrAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&attr)))
 	cbackward, cbackwardAllocMap := (C.int32)(backward), cgoAllocsUnknown
 	cserr, cserrAllocMap := copyPCharBytes((*sliceHeader)(unsafe.Pointer(&serr)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_lun_eclipse_when_loc(ctjdStart, cifl, cgeopos, ctret, cattr, cbackward, cserr)
 	runtime.KeepAlive(cserrAllocMap)
 	runtime.KeepAlive(cbackwardAllocMap)
@@ -996,6 +1109,8 @@ func Pheno(tjd float64, ipl int, iflag int, attr []float64, serr []byte) int32 {
 	ciflag, ciflagAllocMap := (C.int32)(iflag), cgoAllocsUnknown
 	cattr, cattrAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&attr)))
 	cserr, cserrAllocMap := copyPCharBytes((*sliceHeader)(unsafe.Pointer(&serr)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_pheno(ctjd, cipl, ciflag, cattr, cserr)
 	runtime.KeepAlive(cserrAllocMap)
 	runtime.KeepAlive(cattrAllocMap)
@@ -1013,6 +1128,8 @@ func PhenoUt(tjdUt float64, ipl int, iflag int, attr []float64, serr []byte) int
 	ciflag, ciflagAllocMap := (C.int32)(iflag), cgoAllocsUnknown
 	cattr, cattrAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&attr)))
 	cserr, cserrAllocMap := copyPCharBytes((*sliceHeader)(unsafe.Pointer(&serr)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_pheno_ut(ctjdUt, cipl, ciflag, cattr, cserr)
 	runtime.KeepAlive(cserrAllocMap)
 	runtime.KeepAlive(cattrAllocMap)
@@ -1029,6 +1146,8 @@ func Refrac(inalt float64, atpress float64, attemp float64, calcFlag int32) floa
 	catpress, catpressAllocMap := (C.double)(atpress), cgoAllocsUnknown
 	cattemp, cattempAllocMap := (C.double)(attemp), cgoAllocsUnknown
 	ccalcFlag, ccalcFlagAllocMap := (C.int32)(calcFlag), cgoAllocsUnknown
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_refrac(cinalt, catpress, cattemp, ccalcFlag)
 	runtime.KeepAlive(ccalcFlagAllocMap)
 	runtime.KeepAlive(cattempAllocMap)
@@ -1047,6 +1166,8 @@ func RefracExtended(inalt float64, geoalt float64, atpress float64, attemp float
 	clapseRate, clapseRateAllocMap := (C.double)(lapseRate), cgoAllocsUnknown
 	ccalcFlag, ccalcFlagAllocMap := (C.int32)(calcFlag), cgoAllocsUnknown
 	cdret, cdretAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&dret)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_refrac_extended(cinalt, cgeoalt, catpress, cattemp, clapseRate, ccalcFlag, cdret)
 	runtime.KeepAlive(cdretAllocMap)
 	runtime.KeepAlive(ccalcFlagAllocMap)
@@ -1062,6 +1183,8 @@ func RefracExtended(inalt float64, geoalt float64, atpress float64, attemp float
 // SetLapseRate function as declared in src/swephexp.h:887
 func SetLapseRate(lapseRate float64) {
 	clapseRate, clapseRateAllocMap := (C.double)(lapseRate), cgoAllocsUnknown
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	C.swe_set_lapse_rate(clapseRate)
 	runtime.KeepAlive(clapseRateAllocMap)
 }
@@ -1075,6 +1198,8 @@ func Azalt(tjdUt float64, calcFlag int, geopos []float64, atpress float64, attem
 	cattemp, cattempAllocMap := (C.double)(attemp), cgoAllocsUnknown
 	cxin, cxinAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&xin)))
 	cxaz, cxazAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&xaz)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	C.swe_azalt(ctjdUt, ccalcFlag, cgeopos, catpress, cattemp, cxin, cxaz)
 	runtime.KeepAlive(cxazAllocMap)
 	runtime.KeepAlive(cxinAllocMap)
@@ -1092,6 +1217,8 @@ func AzaltRev(tjdUt float64, calcFlag int, geopos []float64, xin []float64, xout
 	cgeopos, cgeoposAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&geopos)))
 	cxin, cxinAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&xin)))
 	cxout, cxoutAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&xout)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	C.swe_azalt_rev(ctjdUt, ccalcFlag, cgeopos, cxin, cxout)
 	runtime.KeepAlive(cxoutAllocMap)
 	runtime.KeepAlive(cxinAllocMap)
@@ -1113,6 +1240,8 @@ func RiseTransTrueHor(tjdUt float64, ipl int, starname []byte, epheflag int, rsm
 	chorhgt, chorhgtAllocMap := (C.double)(horhgt), cgoAllocsUnknown
 	ctret, ctretAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&tret)))
 	cserr, cserrAllocMap := copyPCharBytes((*sliceHeader)(unsafe.Pointer(&serr)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_rise_trans_true_hor(ctjdUt, cipl, cstarname, cepheflag, crsmi, cgeopos, catpress, cattemp, chorhgt, ctret, cserr)
 	runtime.KeepAlive(cserrAllocMap)
 	runtime.KeepAlive(ctretAllocMap)
@@ -1141,6 +1270,8 @@ func RiseTrans(tjdUt float64, ipl int, starname []byte, epheflag int, rsmi int, 
 	cattemp, cattempAllocMap := (C.double)(attemp), cgoAllocsUnknown
 	ctret, ctretAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&tret)))
 	cserr, cserrAllocMap := copyPCharBytes((*sliceHeader)(unsafe.Pointer(&serr)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_rise_trans(ctjdUt, cipl, cstarname, cepheflag, crsmi, cgeopos, catpress, cattemp, ctret, cserr)
 	runtime.KeepAlive(cserrAllocMap)
 	runtime.KeepAlive(ctretAllocMap)
@@ -1167,6 +1298,8 @@ func NodAps(tjdEt float64, ipl int, iflag int, method int, xnasc []float64, xnds
 	cxperi, cxperiAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&xperi)))
 	cxaphe, cxapheAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&xaphe)))
 	cserr, cserrAllocMap := copyPCharBytes((*sliceHeader)(unsafe.Pointer(&serr)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_nod_aps(ctjdEt, cipl, ciflag, cmethod, cxnasc, cxndsc, cxperi, cxaphe, cserr)
 	runtime.KeepAlive(cserrAllocMap)
 	runtime.KeepAlive(cxapheAllocMap)
@@ -1192,6 +1325,8 @@ func NodApsUt(tjdUt float64, ipl int, iflag int, method int, xnasc []float64, xn
 	cxperi, cxperiAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&xperi)))
 	cxaphe, cxapheAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&xaphe)))
 	cserr, cserrAllocMap := copyPCharBytes((*sliceHeader)(unsafe.Pointer(&serr)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_nod_aps_ut(ctjdUt, cipl, ciflag, cmethod, cxnasc, cxndsc, cxperi, cxaphe, cserr)
 	runtime.KeepAlive(cserrAllocMap)
 	runtime.KeepAlive(cxapheAllocMap)
@@ -1213,6 +1348,8 @@ func GetOrbitalElements(tjdEt float64, ipl int, iflag int, dret []float64, serr 
 	ciflag, ciflagAllocMap := (C.int32)(iflag), cgoAllocsUnknown
 	cdret, cdretAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&dret)))
 	cserr, cserrAllocMap := copyPCharBytes((*sliceHeader)(unsafe.Pointer(&serr)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_get_orbital_elements(ctjdEt, cipl, ciflag, cdret, cserr)
 	runtime.KeepAlive(cserrAllocMap)
 	runtime.KeepAlive(cdretAllocMap)
@@ -1232,6 +1369,8 @@ func OrbitMaxMinTrueDistance(tjdEt float64, ipl int, iflag int, dmax []float64, 
 	cdmin, cdminAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&dmin)))
 	cdtrue, cdtrueAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&dtrue)))
 	cserr, cserrAllocMap := copyPCharBytes((*sliceHeader)(unsafe.Pointer(&serr)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_orbit_max_min_true_distance(ctjdEt, cipl, ciflag, cdmax, cdmin, cdtrue, cserr)
 	runtime.KeepAlive(cserrAllocMap)
 	runtime.KeepAlive(cdtrueAllocMap)
@@ -1247,6 +1386,8 @@ func OrbitMaxMinTrueDistance(tjdEt float64, ipl int, iflag int, dmax []float64, 
 // Deltat function as declared in src/swephexp.h:943
 func Deltat(tjd float64) float64 {
 	ctjd, ctjdAllocMap := (C.double)(tjd), cgoAllocsUnknown
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_deltat(ctjd)
 	runtime.KeepAlive(ctjdAllocMap)
 	__v := (float64)(__ret)
@@ -1258,6 +1399,8 @@ func DeltatEx(tjd float64, iflag int, serr []byte) float64 {
 	ctjd, ctjdAllocMap := (C.double)(tjd), cgoAllocsUnknown
 	ciflag, ciflagAllocMap := (C.int32)(iflag), cgoAllocsUnknown
 	cserr, cserrAllocMap := copyPCharBytes((*sliceHeader)(unsafe.Pointer(&serr)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_deltat_ex(ctjd, ciflag, cserr)
 	runtime.KeepAlive(cserrAllocMap)
 	runtime.KeepAlive(ciflagAllocMap)
@@ -1271,6 +1414,8 @@ func TimeEqu(tjd float64, te []float64, serr []byte) int32 {
 	ctjd, ctjdAllocMap := (C.double)(tjd), cgoAllocsUnknown
 	cte, cteAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&te)))
 	cserr, cserrAllocMap := copyPCharBytes((*sliceHeader)(unsafe.Pointer(&serr)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_time_equ(ctjd, cte, cserr)
 	runtime.KeepAlive(cserrAllocMap)
 	runtime.KeepAlive(cteAllocMap)
@@ -1285,6 +1430,8 @@ func LmtToLat(tjdLmt float64, geolon float64, tjdLat []float64, serr []byte) int
 	cgeolon, cgeolonAllocMap := (C.double)(geolon), cgoAllocsUnknown
 	ctjdLat, ctjdLatAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&tjdLat)))
 	cserr, cserrAllocMap := copyPCharBytes((*sliceHeader)(unsafe.Pointer(&serr)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_lmt_to_lat(ctjdLmt, cgeolon, ctjdLat, cserr)
 	runtime.KeepAlive(cserrAllocMap)
 	runtime.KeepAlive(ctjdLatAllocMap)
@@ -1300,6 +1447,8 @@ func LatToLmt(tjdLat float64, geolon float64, tjdLmt []float64, serr []byte) int
 	cgeolon, cgeolonAllocMap := (C.double)(geolon), cgoAllocsUnknown
 	ctjdLmt, ctjdLmtAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&tjdLmt)))
 	cserr, cserrAllocMap := copyPCharBytes((*sliceHeader)(unsafe.Pointer(&serr)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_lat_to_lmt(ctjdLat, cgeolon, ctjdLmt, cserr)
 	runtime.KeepAlive(cserrAllocMap)
 	runtime.KeepAlive(ctjdLmtAllocMap)
@@ -1314,6 +1463,8 @@ func Sidtime0(tjdUt float64, eps float64, nut float64) float64 {
 	ctjdUt, ctjdUtAllocMap := (C.double)(tjdUt), cgoAllocsUnknown
 	ceps, cepsAllocMap := (C.double)(eps), cgoAllocsUnknown
 	cnut, cnutAllocMap := (C.double)(nut), cgoAllocsUnknown
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_sidtime0(ctjdUt, ceps, cnut)
 	runtime.KeepAlive(cnutAllocMap)
 	runtime.KeepAlive(cepsAllocMap)
@@ -1325,6 +1476,8 @@ func Sidtime0(tjdUt float64, eps float64, nut float64) float64 {
 // Sidtime function as declared in src/swephexp.h:953
 func Sidtime(tjdUt float64) float64 {
 	ctjdUt, ctjdUtAllocMap := (C.double)(tjdUt), cgoAllocsUnknown
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_sidtime(ctjdUt)
 	runtime.KeepAlive(ctjdUtAllocMap)
 	__v := (float64)(__ret)
@@ -1334,6 +1487,8 @@ func Sidtime(tjdUt float64) float64 {
 // SetInterpolateNut function as declared in src/swephexp.h:954
 func SetInterpolateNut(doInterpolate int32) {
 	cdoInterpolate, cdoInterpolateAllocMap := (C.AS_BOOL)(doInterpolate), cgoAllocsUnknown
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	C.swe_set_interpolate_nut(cdoInterpolate)
 	runtime.KeepAlive(cdoInterpolateAllocMap)
 }
@@ -1343,6 +1498,8 @@ func Cotrans(xpo []float64, xpn []float64, eps float64) {
 	cxpo, cxpoAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&xpo)))
 	cxpn, cxpnAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&xpn)))
 	ceps, cepsAllocMap := (C.double)(eps), cgoAllocsUnknown
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	C.swe_cotrans(cxpo, cxpn, ceps)
 	runtime.KeepAlive(cepsAllocMap)
 	runtime.KeepAlive(cxpnAllocMap)
@@ -1354,6 +1511,8 @@ func CotransSp(xpo []float64, xpn []float64, eps float64) {
 	cxpo, cxpoAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&xpo)))
 	cxpn, cxpnAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&xpn)))
 	ceps, cepsAllocMap := (C.double)(eps), cgoAllocsUnknown
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	C.swe_cotrans_sp(cxpo, cxpn, ceps)
 	runtime.KeepAlive(cepsAllocMap)
 	runtime.KeepAlive(cxpnAllocMap)
@@ -1362,6 +1521,8 @@ func CotransSp(xpo []float64, xpn []float64, eps float64) {
 
 // GetTidAcc function as declared in src/swephexp.h:961
 func GetTidAcc() float64 {
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_get_tid_acc()
 	__v := (float64)(__ret)
 	return __v
@@ -1370,6 +1531,8 @@ func GetTidAcc() float64 {
 // SetTidAcc function as declared in src/swephexp.h:962
 func SetTidAcc(tAcc float64) {
 	ctAcc, ctAccAllocMap := (C.double)(tAcc), cgoAllocsUnknown
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	C.swe_set_tid_acc(ctAcc)
 	runtime.KeepAlive(ctAccAllocMap)
 }
@@ -1377,6 +1540,8 @@ func SetTidAcc(tAcc float64) {
 // SetDeltaTUserdef function as declared in src/swephexp.h:966
 func SetDeltaTUserdef(dt float64) {
 	cdt, cdtAllocMap := (C.double)(dt), cgoAllocsUnknown
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	C.swe_set_delta_t_userdef(cdt)
 	runtime.KeepAlive(cdtAllocMap)
 }
@@ -1384,6 +1549,8 @@ func SetDeltaTUserdef(dt float64) {
 // Degnorm function as declared in src/swephexp.h:968
 func Degnorm(x float64) float64 {
 	cx, cxAllocMap := (C.double)(x), cgoAllocsUnknown
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_degnorm(cx)
 	runtime.KeepAlive(cxAllocMap)
 	__v := (float64)(__ret)
@@ -1393,6 +1560,8 @@ func Degnorm(x float64) float64 {
 // Radnorm function as declared in src/swephexp.h:969
 func Radnorm(x float64) float64 {
 	cx, cxAllocMap := (C.double)(x), cgoAllocsUnknown
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_radnorm(cx)
 	runtime.KeepAlive(cxAllocMap)
 	__v := (float64)(__ret)
@@ -1403,6 +1572,8 @@ func Radnorm(x float64) float64 {
 func RadMidp(x1 float64, x0 float64) float64 {
 	cx1, cx1AllocMap := (C.double)(x1), cgoAllocsUnknown
 	cx0, cx0AllocMap := (C.double)(x0), cgoAllocsUnknown
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_rad_midp(cx1, cx0)
 	runtime.KeepAlive(cx0AllocMap)
 	runtime.KeepAlive(cx1AllocMap)
@@ -1414,6 +1585,8 @@ func RadMidp(x1 float64, x0 float64) float64 {
 func DegMidp(x1 float64, x0 float64) float64 {
 	cx1, cx1AllocMap := (C.double)(x1), cgoAllocsUnknown
 	cx0, cx0AllocMap := (C.double)(x0), cgoAllocsUnknown
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_deg_midp(cx1, cx0)
 	runtime.KeepAlive(cx0AllocMap)
 	runtime.KeepAlive(cx1AllocMap)
@@ -1430,6 +1603,8 @@ func SplitDeg(ddeg float64, roundflag int, ideg []int, imin []int, isec []int, d
 	cisec, cisecAllocMap := copyPInt32Bytes((*sliceHeader)(unsafe.Pointer(&isec)))
 	cdsecfr, cdsecfrAllocMap := copyPDoubleBytes((*sliceHeader)(unsafe.Pointer(&dsecfr)))
 	cisgn, cisgnAllocMap := copyPInt32Bytes((*sliceHeader)(unsafe.Pointer(&isgn)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	C.swe_split_deg(cddeg, croundflag, cideg, cimin, cisec, cdsecfr, cisgn)
 	runtime.KeepAlive(cisgnAllocMap)
 	runtime.KeepAlive(cdsecfrAllocMap)
@@ -1443,6 +1618,8 @@ func SplitDeg(ddeg float64, roundflag int, ideg []int, imin []int, isec []int, d
 // Csnorm function as declared in src/swephexp.h:982
 func Csnorm(p int32) int32 {
 	cp, cpAllocMap := (C.centisec)(p), cgoAllocsUnknown
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_csnorm(cp)
 	runtime.KeepAlive(cpAllocMap)
 	__v := (int32)(__ret)
@@ -1453,6 +1630,8 @@ func Csnorm(p int32) int32 {
 func Difcsn(p1 int, p2 int32) int32 {
 	cp1, cp1AllocMap := (C.centisec)(p1), cgoAllocsUnknown
 	cp2, cp2AllocMap := (C.centisec)(p2), cgoAllocsUnknown
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_difcsn(cp1, cp2)
 	runtime.KeepAlive(cp2AllocMap)
 	runtime.KeepAlive(cp1AllocMap)
@@ -1464,6 +1643,8 @@ func Difcsn(p1 int, p2 int32) int32 {
 func Difdegn(p1 float64, p2 float64) float64 {
 	cp1, cp1AllocMap := (C.double)(p1), cgoAllocsUnknown
 	cp2, cp2AllocMap := (C.double)(p2), cgoAllocsUnknown
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_difdegn(cp1, cp2)
 	runtime.KeepAlive(cp2AllocMap)
 	runtime.KeepAlive(cp1AllocMap)
@@ -1475,6 +1656,8 @@ func Difdegn(p1 float64, p2 float64) float64 {
 func Difcs2n(p1 int, p2 int32) int32 {
 	cp1, cp1AllocMap := (C.centisec)(p1), cgoAllocsUnknown
 	cp2, cp2AllocMap := (C.centisec)(p2), cgoAllocsUnknown
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_difcs2n(cp1, cp2)
 	runtime.KeepAlive(cp2AllocMap)
 	runtime.KeepAlive(cp1AllocMap)
@@ -1486,6 +1669,8 @@ func Difcs2n(p1 int, p2 int32) int32 {
 func Difdeg2n(p1 float64, p2 float64) float64 {
 	cp1, cp1AllocMap := (C.double)(p1), cgoAllocsUnknown
 	cp2, cp2AllocMap := (C.double)(p2), cgoAllocsUnknown
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_difdeg2n(cp1, cp2)
 	runtime.KeepAlive(cp2AllocMap)
 	runtime.KeepAlive(cp1AllocMap)
@@ -1497,6 +1682,8 @@ func Difdeg2n(p1 float64, p2 float64) float64 {
 func Difrad2n(p1 float64, p2 float64) float64 {
 	cp1, cp1AllocMap := (C.double)(p1), cgoAllocsUnknown
 	cp2, cp2AllocMap := (C.double)(p2), cgoAllocsUnknown
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_difrad2n(cp1, cp2)
 	runtime.KeepAlive(cp2AllocMap)
 	runtime.KeepAlive(cp1AllocMap)
@@ -1507,6 +1694,8 @@ func Difrad2n(p1 float64, p2 float64) float64 {
 // Csroundsec function as declared in src/swephexp.h:996
 func Csroundsec(x int32) int32 {
 	cx, cxAllocMap := (C.centisec)(x), cgoAllocsUnknown
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_csroundsec(cx)
 	runtime.KeepAlive(cxAllocMap)
 	__v := (int32)(__ret)
@@ -1516,6 +1705,8 @@ func Csroundsec(x int32) int32 {
 // D2l function as declared in src/swephexp.h:999
 func D2l(x float64) int32 {
 	cx, cxAllocMap := (C.double)(x), cgoAllocsUnknown
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_d2l(cx)
 	runtime.KeepAlive(cxAllocMap)
 	__v := (int32)(__ret)
@@ -1525,6 +1716,8 @@ func D2l(x float64) int32 {
 // DayOfWeek function as declared in src/swephexp.h:1002
 func DayOfWeek(jd float64) int32 {
 	cjd, cjdAllocMap := (C.double)(jd), cgoAllocsUnknown
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_day_of_week(cjd)
 	runtime.KeepAlive(cjdAllocMap)
 	__v := (int32)(__ret)
@@ -1537,6 +1730,8 @@ func Cs2timestr(t int, sep int, suppressZero int, a []byte) *byte {
 	csep, csepAllocMap := (C.int)(sep), cgoAllocsUnknown
 	csuppressZero, csuppressZeroAllocMap := (C.AS_BOOL)(suppressZero), cgoAllocsUnknown
 	ca, caAllocMap := copyPCharBytes((*sliceHeader)(unsafe.Pointer(&a)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_cs2timestr(ct, csep, csuppressZero, ca)
 	runtime.KeepAlive(caAllocMap)
 	runtime.KeepAlive(csuppressZeroAllocMap)
@@ -1552,6 +1747,8 @@ func Cs2lonlatstr(t int, pchar byte, mchar byte, s []byte) *byte {
 	cpchar, cpcharAllocMap := (C.char)(pchar), cgoAllocsUnknown
 	cmchar, cmcharAllocMap := (C.char)(mchar), cgoAllocsUnknown
 	cs, csAllocMap := copyPCharBytes((*sliceHeader)(unsafe.Pointer(&s)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_cs2lonlatstr(ct, cpchar, cmchar, cs)
 	runtime.KeepAlive(csAllocMap)
 	runtime.KeepAlive(cmcharAllocMap)
@@ -1565,6 +1762,8 @@ func Cs2lonlatstr(t int, pchar byte, mchar byte, s []byte) *byte {
 func Cs2degstr(t int, a []byte) *byte {
 	ct, ctAllocMap := (C.centisec)(t), cgoAllocsUnknown
 	ca, caAllocMap := copyPCharBytes((*sliceHeader)(unsafe.Pointer(&a)))
+	swephgoMutex.Lock()
+	defer swephgoMutex.Unlock()
 	__ret := C.swe_cs2degstr(ct, ca)
 	runtime.KeepAlive(caAllocMap)
 	runtime.KeepAlive(ctAllocMap)


### PR DESCRIPTION
swephgoMutex was added to prevent variables from being corrupted in memory due to concurrent writes in multi-threaded environments.